### PR TITLE
Use updated analysis-backend endpoint for opportunity datasets

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,9 +31,8 @@ app.post('/api', function (request, response) {
 });
 
 app.post('/grid', function (request, response) {
-  let gridRegionID = request.body.gridRegionID;
-  let gridName = request.body.gridName;
-  fetch("https://analysis.conveyal.com/api/opportunities/" + gridRegionID + "/" + gridName, {
+  let id = request.body.opportunityDatasetId;
+  fetch("https://analysis.conveyal.com/api/opportunities/" + id, {
     method: 'GET',
     headers: {
       "Content-Type": "application/json",

--- a/src/components/Map/ScenarioMap/ScenarioMap.js
+++ b/src/components/Map/ScenarioMap/ScenarioMap.js
@@ -29,8 +29,6 @@ import {
   NetworkInfo,
   CorridorInfo,
   PROJECT_ID,
-  GRID_REGION_ID,
-  GRID_NAME,
   BaselineRequest,
   NewScenarioRequest,
   API_URL,
@@ -71,8 +69,7 @@ class ScenarioMap extends React.Component {
       },
       body: JSON.stringify(
         {
-          gridRegionID: GRID_REGION_ID,
-          gridName: GRID_NAME,
+          opportunityDatasetId: OPPORTUNITY_DATASET_ID
         }
       )
     })

--- a/src/config.js
+++ b/src/config.js
@@ -54,6 +54,7 @@ export const ZoomLevel = 13;
  */
 export const Tile = 'https://api.mapbox.com/styles/v1/ctrob/civ2rkezr00042ilnogrj4zjm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiY3Ryb2IiLCJhIjoiY2lrZTh5ajZkMDAzcnZmbHo4ZzBjdTBiaSJ9.vcZYiN_V3wV-VS3-KMoQdg';
 
+// Use the _id value for the desired opportunity dataset, which  can be determined by inspecting the response to a request to load the Opportunity Dataset page in Conveyal Analysis.
 export const OPPORTUNITY_DATASET_ID = "12345ABCDE"
 
 export const PROJECT_ID = "5a29eca1896fd005dc77a631";

--- a/src/config.js
+++ b/src/config.js
@@ -54,9 +54,7 @@ export const ZoomLevel = 13;
  */
 export const Tile = 'https://api.mapbox.com/styles/v1/ctrob/civ2rkezr00042ilnogrj4zjm/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiY3Ryb2IiLCJhIjoiY2lrZTh5ajZkMDAzcnZmbHo4ZzBjdTBiaSJ9.vcZYiN_V3wV-VS3-KMoQdg';
 
-export const GRID_REGION_ID = "5a29e7d3896fd005dc77a617";
-
-export const GRID_NAME = "Jobs_total";
+export const OPPORTUNITY_DATASET_ID = "12345ABCDE"
 
 export const PROJECT_ID = "5a29eca1896fd005dc77a631";
 


### PR DESCRIPTION
CoAXs fetches opportunity datasets (e.g. grids with the number of jobs in each cell) from the same S3 bucket used by Conveyal Analysis.  To do so, it first requests a presigned URL from the analysis.conveyal.com/api/opportunities/:regionId/:gridId endpoint.  This endpoint has been deprecated, so future CoAXs sites will need to use the new endpoint, as suggested in this PR.

The `OPPORTUNITY_DATASET_ID` value in the CoAXs config file should be set to the `_id` value for the desired grid, which can be determined using the network tab of a browser's dev tools when opening the Opportunity Dataset view in Conveyal Analysis:

![image](https://user-images.githubusercontent.com/2173529/43667822-b3779436-9747-11e8-9b47-595333e8ad9f.png)
